### PR TITLE
[Device-data-volume-subscriptions]: remove allof in sinkcredential

### DIFF
--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -327,10 +327,8 @@ components:
           format: url
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
+        sinkCredential:      
+          $ref: "#/components/schemas/SinkCredential"
         types:
           description: |
             Event types eligible to be delivered by this subscription for device quality indicators.
@@ -382,6 +380,7 @@ components:
             Set to `true` if the consumer wants an event triggered immediately if the current situation reflects the event request.
 
     SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
       type: object
       properties:
         credentialType:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -327,7 +327,7 @@ components:
           format: url
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:      
+        sinkCredential:
           $ref: "#/components/schemas/SinkCredential"
         types:
           description: |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:

Removing this allOf.
It was discovered for some code-generator, it will produce unexpected behaviors having the description inside the allOf.


#### Which issue(s) this PR fixes:

Fixes #26 

#### Changelog input

```
[Device-data-volume-subscriptions]: remove `allOf` in `sinkCredential` in `SubscriptionRequest` component

```
