### PR TITLE
Remove line ending rule from Gherkin linting rules

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -23,7 +23,6 @@
     }
   ],
   "no-trailing-spaces": "on",
-  "new-line-at-eof": ["on", "no"],
   "no-multiple-empty-lines": "on",
   "no-empty-file": "on",
   "no-scenario-outlines-without-examples": "on",


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Existing line ending rule causes problems when feature files are edited using the Github web editor

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #41 

#### Special notes for reviewers:
See issue for details

#### Changelog input

```
 release-note
 - Remove line ending rule from Gherkin linting rules
```

#### Additional documentation 
None
