### PR TITLE
chore: migrate swagger editor links to CAMARA swagger-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Version 0.1.0-alpha.1 is the first alpha release of device-data-volume
 
 - API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceDataVolume/blob/r1.1/code/API_definitions/device-data-volume.yaml)
 
 ### Added
@@ -31,7 +31,7 @@ Version 0.1.0-alpha.1 is the first alpha release of device-data-volume-subscript
 
 - API definition **with inline documentation**:
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
   - OpenAPI [YAML spec file](https://github.com/camaraproject/DeviceDataVolume/blob/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Sandbox API Repository to describe, develop, document, and test the Device Data 
   * **device-data-volume v0.1.0-alpha.1**  
   [[YAML]](https://github.com/camaraproject/DeviceDataVolume/blob/r1.1/code/API_definitions/device-data-volume.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume.yaml)
   * **device-data-volume-subscriptions v0.1.0-alpha.1**  
   [[YAML]](https://github.com/camaraproject/DeviceDataVolume/blob/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
   [[View it on ReDoc]](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml&nocors)
-  [[View it on Swagger Editor]](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
+  [[View it on Swagger Editor]](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/DeviceDataVolume/r1.1/code/API_definitions/device-data-volume-subscriptions.yaml)
 
 - Current work-in-progress version is available within the [main branch](https://github.com/camaraproject/DeviceDataVolume)
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation
* subproject management


#### What this PR does / why we need it:
This pull request migrates swagger editor links to use the CAMARA project's dedicated swagger-ui instance for better reliability (original links to swagger.io were broken).

**Changes:**
* Replaced https://editor.swagger.io/ with https://camaraproject.github.io/swagger-ui/
* Replaced https://editor-next.swagger.io/ with https://camaraproject.github.io/swagger-ui/
* All API specification URLs remain unchanged - only the swagger editor host is updated 

**Benefits:**
Consistent CAMARA experience Centralized swagger-ui configuration Maintained compatibility with existing specification URLs




#### Which issue(s) this PR fixes:
Fixes #44 
