### PR TITLE
Update OAS and test definitions to remove IDENTIFIER_MISMATCH error code

### DIFF
--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -1508,7 +1508,9 @@ components:
           subscriptionMaxEvents: 5
           initialEvent: true
         id: 550e8400-e29b-41d4-a716-446655440000
-        status: ACTIVATION_REQUESTED
+        status: ACTIVE
+        startsAt: '2023-01-17T12:27:08.312Z'
+        expiresAt: '2023-01-17T13:18:23.682Z'
 
     SUBSCRIPTION_CREATION_WITH_DEVICE_DISAMBIGUATION:
       description: A new subscription has been successfully created
@@ -1527,7 +1529,9 @@ components:
           subscriptionMaxEvents: 5
           initialEvent: true
         id: 550e8400-e29b-41d4-a716-446655440000
-        status: ACTIVATION_REQUESTED
+        status: ACTIVE
+        startsAt: '2023-01-17T12:27:08.312Z'
+        expiresAt: '2023-01-17T13:18:23.682Z'
 
     ACTIVE_SUBSCRIPTION:
       description: Details of an active subscription
@@ -1543,8 +1547,8 @@ components:
           subscriptionMaxEvents: 10
           initialEvent: true
         status: ACTIVE
-        startsAt: "2024-06-15T09:30:02.871Z"
-        expiresAt: "2024-08-01T14:18:23.682Z"
+        startsAt: '2023-01-17T12:27:08.312Z'
+        expiresAt: '2023-01-17T13:18:23.682Z'
 
     ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION:
       description: Details of an active subscription with device details for disambiguation
@@ -1562,8 +1566,8 @@ components:
           subscriptionMaxEvents: 10
           initialEvent: true
         status: ACTIVE
-        startsAt: "2024-06-15T09:30:02.871Z"
-        expiresAt: "2024-08-01T14:18:23.682Z"
+        startsAt: '2023-01-17T12:27:08.312Z'
+        expiresAt: '2023-01-17T13:18:23.682Z'
 
     SUBSCRIPTION_LIST:
       description: A list of API consumer subscriptions. If a 3-legged access token is used, the list is specific to the device associated with that token.
@@ -1579,8 +1583,8 @@ components:
             subscriptionMaxEvents: 10
             initialEvent: true
           status: ACTIVE
-          startsAt: "2024-06-15T09:30:02.871Z"
-          expiresAt: "2024-08-01T14:18:23.682Z"
+          startsAt: '2023-01-17T12:27:08.312Z'
+          expiresAt: '2023-01-17T13:18:23.682Z'
 
     EMPTY_SUBSCRIPTION_LIST:
       description: The API consumer either has no subscriptions or, if a 3-legged access token is used, has none for the device associated with that token.

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -614,6 +614,16 @@ components:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
 
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
+
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
       type: string
@@ -847,7 +857,7 @@ components:
         - subscriptionId
       properties:
         device:
-          $ref: "#/components/schemas/Device"
+          $ref: "#/components/schemas/DeviceResponse"
         subscriptionId:
           $ref: "#/components/schemas/SubscriptionId"
 
@@ -1334,19 +1344,12 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - MISSING_IDENTIFIER
                       - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -180,6 +180,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Subscription"
+              examples:
+                Successful Subscription Creation:
+                  $ref: "#/components/examples/SUBSCRIPTION_CREATION"
+                Successful Subscription Creation With Device Disambiguation:
+                  $ref: "#/components/examples/SUBSCRIPTION_CREATION_WITH_DEVICE_DISAMBIGUATION"
         "202":
           description: Request accepted to be processed. It applies for async creation process.
           headers:
@@ -225,6 +230,11 @@ paths:
                 minItems: 0
                 items:
                   $ref: "#/components/schemas/Subscription"
+              examples:
+                Subscription List:
+                  $ref: "#/components/examples/SUBSCRIPTION_LIST"
+                Empty Subscription List:
+                  $ref: "#/components/examples/EMPTY_SUBSCRIPTION_LIST"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -256,8 +266,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Subscription"
               examples:
-                subscription-active:
-                  $ref: "#/components/examples/SUBSCRIPTION_ACTIVE"
+                Active Subscription:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION"
+                Active Subscription With Device Disambiguation:
+                  $ref: "#/components/examples/ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION"
         "400":
           $ref: "#/components/responses/SubscriptionIdRequired400"
         "401":
@@ -1481,7 +1493,61 @@ components:
           subscriptionId: dv10-h556-rt89-1403
         time: "2024-03-05T15:00:23.682Z"
 
-    SUBSCRIPTION_ACTIVE:
+    SUBSCRIPTION_CREATION:
+      description: A new subscription has been successfully created
+      value:
+        protocol: HTTP
+        protocolSettings:
+          method: POST
+        sink: https://endpoint.example.com/sink
+        types:
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: '2023-01-17T13:18:23.682Z'
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        id: 550e8400-e29b-41d4-a716-446655440000
+        status: ACTIVATION_REQUESTED
+
+    SUBSCRIPTION_CREATION_WITH_DEVICE_DISAMBIGUATION:
+      description: A new subscription has been successfully created
+      value:
+        protocol: HTTP
+        protocolSettings:
+          method: POST
+        sink: https://endpoint.example.com/sink
+        types:
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
+        config:
+          subscriptionDetail:
+            device:
+              phoneNumber: "+123456789"
+          subscriptionExpireTime: '2023-01-17T13:18:23.682Z'
+          subscriptionMaxEvents: 5
+          initialEvent: true
+        id: 550e8400-e29b-41d4-a716-446655440000
+        status: ACTIVATION_REQUESTED
+
+    ACTIVE_SUBSCRIPTION:
+      description: Details of an active subscription
+      value:
+        id: 550e8400-e29b-41d4-a716-446655440001
+        sink: https://endpoint.example.com/sink
+        protocol: HTTP
+        types:
+          - "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+        config:
+          subscriptionDetail: {}
+          subscriptionExpireTime: "2024-08-01T14:18:23.682Z"
+          subscriptionMaxEvents: 10
+          initialEvent: true
+        status: ACTIVE
+        startsAt: "2024-06-15T09:30:02.871Z"
+        expiresAt: "2024-08-01T14:18:23.682Z"
+
+    ACTIVE_SUBSCRIPTION_WITH_DEVICE_DISAMBIGUATION:
+      description: Details of an active subscription with device details for disambiguation
       value:
         id: 550e8400-e29b-41d4-a716-446655440001
         sink: https://endpoint.example.com/sink
@@ -1495,5 +1561,27 @@ components:
           subscriptionExpireTime: "2024-08-01T14:18:23.682Z"
           subscriptionMaxEvents: 10
           initialEvent: true
+        status: ACTIVE
         startsAt: "2024-06-15T09:30:02.871Z"
         expiresAt: "2024-08-01T14:18:23.682Z"
+
+    SUBSCRIPTION_LIST:
+      description: A list of API consumer subscriptions. If a 3-legged access token is used, the list is specific to the device associated with that token.
+      value:
+        - id: 550e8400-e29b-41d4-a716-446655440001
+          sink: https://endpoint.example.com/sink
+          protocol: HTTP
+          types:
+            - "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+          config:
+            subscriptionDetail: {}
+            subscriptionExpireTime: "2024-08-01T14:18:23.682Z"
+            subscriptionMaxEvents: 10
+            initialEvent: true
+          status: ACTIVE
+          startsAt: "2024-06-15T09:30:02.871Z"
+          expiresAt: "2024-08-01T14:18:23.682Z"
+
+    EMPTY_SUBSCRIPTION_LIST:
+      description: The API consumer either has no subscriptions or, if a 3-legged access token is used, has none for the device associated with that token.
+      value: []

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -526,7 +526,7 @@ components:
       description: Successfully retrieve the device data volume category
       value:
         dataVolumeCategory: "<200MiB"
-    SuccessfulRetrieveResponse:
+    SuccessfulRetrieveResponseWithDeviceDisambiguation:
       description: Successfully retrieve the device data volume category but device disambiguation is required
       value:
         device:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -12,7 +12,11 @@ info:
 
     # Relevant terms and definitions
 
-    * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication. At least one identifier for the device (user equipment) out of four options: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device.
+    * **Device**: A device refers to any physical entity that can connect to a network and participate in network communication.
+
+        At least one identifier for the device out of four options must be provided: IPv4 address, IPv6 address, Phone number, or Network Access Identifier assigned by the mobile network operator for the device. Where more than one device identifier is provided, only one identifier will be selected by the implementation and this choice indicated to the API consumer in the session creation response.
+
+        Note: Network Access Identifier is defined for future use and will not be supported with this version of the API.
 
     # API Functionality
 
@@ -101,6 +105,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RetrieveDataVolumeResponse"
+              examples:
+                Successful Response:
+                  $ref: "#/components/examples/SuccessfulRetrieveResponse"
+                Successful Response With Device Disambiguation:
+                  $ref: "#/components/examples/SuccessfulRetrieveResponseWithDeviceDisambiguation"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -140,6 +149,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CheckDataVolumeResponse"
+              examples:
+                Successful Response:
+                  $ref: "#/components/examples/SuccessfulCheckResponse"
+                Successful Response With Device Disambiguation:
+                  $ref: "#/components/examples/SuccessfulCheckResponseWithDeviceDisambiguation"
         "400":
           $ref: "#/components/responses/Generic400"
         "401":
@@ -207,6 +221,8 @@ components:
       description: Represents the response, if the data volume exceeds a given threshold.
       type: object
       properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         thresholdExceeded:
           type: boolean
           description: Indicates whether the remaining data volume exceeds the given threshold
@@ -226,6 +242,8 @@ components:
       description: Represents the remaining data volume of the requested device.
       type: object
       properties:
+        device:
+          $ref: "#/components/schemas/DeviceResponse"
         dataVolumeCategory:
           $ref: "#/components/schemas/DataVolumeCategory"
       required:
@@ -261,6 +279,16 @@ components:
         ipv6Address:
           $ref: "#/components/schemas/DeviceIpv6Address"
       minProperties: 1
+
+    DeviceResponse:
+      description: |
+        An identifier for the end-user equipment able to connect to the network that the response refers to. This parameter is only returned when the API consumer includes the `device` parameter in their request (i.e. they are using a two-legged access token), and is relevant when more than one device identifier is specified, as only one of those device identifiers is allowed in the response.
+
+        If the API consumer provides more than one device identifier in their request, the API provider must return a single identifier which is the one they are using to fulfil the request, even if the identifiers do not match the same device. API provider does not perform any logic to validate/correlate that the indicated device identifiers match the same device. No error should be returned if the identifiers are otherwise valid to prevent API consumers correlating different identifiers with a given end user.
+
+      allOf:
+        - $ref: "#/components/schemas/Device"
+        - maxProperties: 1
 
     PhoneNumber:
       description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
@@ -461,18 +489,11 @@ components:
                       - 422
                   code:
                     enum:
-                      - IDENTIFIER_MISMATCH
                       - MISSING_IDENTIFIER
                       - SERVICE_NOT_APPLICABLE
                       - UNNECESSARY_IDENTIFIER
                       - UNSUPPORTED_IDENTIFIER
           examples:
-            GENERIC_422_IDENTIFIER_MISMATCH:
-              description: Inconsistency between identifiers not pointing to the same device
-              value:
-                status: 422
-                code: IDENTIFIER_MISMATCH
-                message: Provided identifiers are not consistent.
             GENERIC_422_SERVICE_NOT_APPLICABLE:
               description: Service not applicable for the provided identifier
               value:
@@ -499,3 +520,25 @@ components:
                 status: 422
                 code: UNSUPPORTED_IDENTIFIER
                 message: The identifier provided is not supported.
+
+  examples:
+    SuccessfulRetrieveResponse:
+      description: Successfully retrieve the device data volume category
+      value:
+        dataVolumeCategory: "<200MiB"
+    SuccessfulRetrieveResponse:
+      description: Successfully retrieve the device data volume category but device disambiguation is required
+      value:
+        device:
+          phoneNumber: "+123456789"
+        dataVolumeCategory: "<200MiB"
+    SuccessfulCheckResponse:
+      description: Successfully check the device data volume category
+      value:
+        thresholdExceeded: false
+    SuccessfulCheckResponseWithDeviceDisambiguation:
+      description: Successfully check the device data volume category but device disambiguation is required
+      value:
+        device:
+          phoneNumber: "+123456789"
+        thresholdExceeded: true

--- a/code/Test_definitions/device-data-volume-checkDataVolume.feature
+++ b/code/Test_definitions/device-data-volume-checkDataVolume.feature
@@ -132,19 +132,6 @@ Feature: CAMARA Device Data Volume API, vwip - Operation checkDataVolume
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @device_data_volume_checkDataVolume_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "checkDataVolume" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 #################
 # Error code 401
 #################

--- a/code/Test_definitions/device-data-volume-retrieveDataVolume.feature
+++ b/code/Test_definitions/device-data-volume-retrieveDataVolume.feature
@@ -119,19 +119,6 @@ Feature: CAMARA Device Data Volume API, vwip - Operation retrieveDataVolume
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
-  # Several identifiers provided but they do not identify the same device
-  # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @device_data_volume_retrieveDataVolume_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "retrieveDataVolume" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 #################
 # Error code 401
 #################

--- a/code/Test_definitions/device-data-volume-subscriptions.feature
+++ b/code/Test_definitions/device-data-volume-subscriptions.feature
@@ -327,19 +327,6 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation createDeviceData
     And the response property "$.code" is "SERVICE_NOT_APPLICABLE"
     And the response property "$.message" contains a user-friendly text
 
- # Several identifiers provided but they do not identify the same device
- # This scenario may happen with 2-legged access tokens, which do not identify a device
-  @device_data_volume_subscriptions_C01.08_device_identifiers_mismatch
-  Scenario: Device identifiers mismatch
-    Given the header "Authorization" is set to a valid access token which does not identify a single device
-    And at least 2 types of device identifiers are supported by the implementation
-    And the request body property "$.device" includes several identifiers, each of them identifying a valid but different device
-    When the request "createDeviceDataVolumeSubscription" is sent
-    Then the response status code is 422
-    And the response property "$.status" is 422
-    And the response property "$.code" is "IDENTIFIER_MISMATCH"
-    And the response property "$.message" contains a user friendly text
-
 ##################
 # Error code 400
 ##################


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Commonalities has removed the `IDENTIFIER_MISMATCH` error for Fall25. Instead, a device identifier should not normally be included in responses. It should only be included to disambiguate the identity of the device when:
- the endpoint is being accessed using a 2-legged access token; and
- the endpoint allows for a device identifier to be provided in the request; and
- the API consumer has included multiple device identifiers

The response then includes the device identifier that was used by the implementation

This PR:
- Updates documentation in each OAS
- Adds relevant examples both for when device disambiguation is required, and when it is not required
- Uses `DeviceResponse` object for the device-data-volume API to limit device identifiers in responses to exactly one
- Removes the `IDENTIFIER_MISMATCH` error code option from 422 responses

Note; For subscriptions, the `CreateSubscriptionDetail` schema is used in both requests and responses, so modifying the responses to use the `DeviceResponse` would require a general update of the subscription schema in Commonalities. For the moment, the existing schema is left unmodified, which means that multiple device identifiers could be provided in responses, but should not.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #50 

#### Special notes for reviewers:
I think both GET endpoints should never return a device identifier in the responses, but haven't thought through all possible scenarios, so will raise this as a separate issue.

#### Changelog input

```
 release-note
 - Update documentation in each OAS
 - Add relevant examples both for when device disambiguation is required, and when it is not required
 - Use DeviceResponse object for the device-data-volume API to limit device identifiers in responses to exactly one
 - Remove the IDENTIFIER_MISMATCH error code option from 422 responses and test cases
```

#### Additional documentation 
None
