### PR TITLE
[Admin] Append Local to overridden common schemas to avoid renaming validation warnings

### DIFF
--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -438,7 +438,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config"
+          $ref: "#/components/schemas/Config2"
         id:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
         startsAt:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -362,7 +362,7 @@ components:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
 
-    Config:
+    Config2:
       description: Config schema allowing for device to be specified as part of subscription detail
       allOf:
         - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
@@ -496,7 +496,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config"
+          $ref: "#/components/schemas/Config2"
       discriminator:
         propertyName: protocol
         mapping:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -355,21 +355,21 @@ components:
         $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
 
   schemas:
-    SubscriptionDetail:
+    SubscriptionDetailLocal:
       description: The details of the requested device data volume subscription.
       type: object
       properties:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
 
-    Config2:
+    ConfigLocal:
       description: Config schema allowing for device to be specified as part of subscription detail
       allOf:
         - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
         - type: object
           properties:
             subscriptionDetail:
-              $ref: "#/components/schemas/SubscriptionDetail"
+              $ref: "#/components/schemas/SubscriptionDetailLocal"
 
     ApiEventType:
       type: string
@@ -440,7 +440,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config2"
+          $ref: "#/components/schemas/ConfigLocal"
         id:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
         startsAt:
@@ -498,7 +498,7 @@ components:
           items:
             $ref: "#/components/schemas/ApiEventType"
         config:
-          $ref: "#/components/schemas/Config2"
+          $ref: "#/components/schemas/ConfigLocal"
       discriminator:
         propertyName: protocol
         mapping:


### PR DESCRIPTION
#### What type of PR is this?
* correction


#### What this PR does / why we need it:
YAML expansion results in overridden common schemas being having `-2` appended, which then falls fowl of the "PascalCase should be used" warning. This PR renames the overridden schema by appending `Local` to avoid this.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #88 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - [Admin] Append Local to overridden common schemas to avoid renaming validation warnings
```

#### Additional documentation 
None