### PR TITLE
[Added] Add lastStatusTime field to successful responses with examples

### DIFF
--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -204,8 +204,7 @@ components:
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       allOf:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        - type: string
-          nullable: true
+        - nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.
@@ -317,13 +316,16 @@ components:
     CheckRequest:
       description: Request device data volume category check with 3-legged access token
       value:
-        volumeToCheck: "<200MiB"
+          value: 500
+          units: "MiB"
     CheckRequestWith2-leggedAccessToken:
       description: Request device data volume category check with 2-legged access token
       value:
         device:
           phoneNumber: "+123456789"
-        volumeToCheck: "<200MiB"
+        volumeToCheck:
+          value: 500
+          units: "MiB"
     SuccessfulCheckResponse:
       description: Successfully check the device data volume category with known status time
       value:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -319,7 +319,7 @@ components:
       value:
         volumeToCheck:
           value: 500
-          units: "MiB"
+          unit: "MiB"
     CheckRequestWith2-leggedAccessToken:
       description: Request device data volume category check with 2-legged access token
       value:
@@ -327,7 +327,7 @@ components:
           phoneNumber: "+123456789"
         volumeToCheck:
           value: 500
-          units: "MiB"
+          unit: "MiB"
     SuccessfulCheckResponse:
       description: Successfully check the device data volume category with known status time
       value:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -206,12 +206,6 @@ components:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
         - nullable: true
 
-      #      type: string
-      #      format: date-time
-      #      maxLength: 64
-      #      example: "2018-04-05T17:31:00Z"
-      #      nullable: true
-
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.
       type: string

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,11 +202,9 @@ components:
       description: |
         The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      type: string
-      format: date-time
-      maxLength: 64
+      allOf:
+        - $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
       nullable: true
-      example: "2018-04-05T17:31:00Z"
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -204,7 +204,7 @@ components:
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       allOf:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        - type: object
+        - type: string
           nullable: true
 
     VolumeUnitEnum:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -200,11 +200,13 @@ components:
   schemas:
     LastStatusTime:
       description: |
-        The last time that the device date volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
+        The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      type: string
+      format: date-time
+      maxLength: 64
       nullable: true
-      allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+      example: "2018-04-05T17:31:00Z"
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -204,7 +204,6 @@ components:
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       type: string
       allOf:
-        - type: string
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
       nullable: true
 

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,6 +202,7 @@ components:
       description: |
         The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      type: string
       allOf:
         - type: string
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -317,6 +317,7 @@ components:
     CheckRequest:
       description: Request device data volume category check with 3-legged access token
       value:
+        volumeToCheck:
           value: 500
           units: "MiB"
     CheckRequestWith2-leggedAccessToken:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -106,9 +106,9 @@ paths:
               $ref: "#/components/schemas/RetrieveDataVolumeRequest"
             examples:
               Successful Retrieve Response:
-                $ref: "#/components/examples/SuccessfulRetrieveResponse
+                $ref: "#/components/examples/SuccessfulRetrieveResponse"
               Successful Retrieve Response With Unknown Status Time:
-                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime
+                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime"
       responses:
         "200":
           description: Contains information about the remaining device data volume.
@@ -159,9 +159,9 @@ paths:
               $ref: "#/components/schemas/CheckDataVolumeRequest"
             examples:
               Successful Retrieve Response:
-                $ref: "#/components/examples/SuccessfulRetrieveResponse
+                $ref: "#/components/examples/SuccessfulRetrieveResponse"
               Successful Retrieve Response With Unknown Status Time:
-                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime
+                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime"
       responses:
         "200":
           description: Boolean response indicating if the remaining data volume exceeds the provided threshold

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -99,11 +99,16 @@ paths:
         - openId:
             - device-data-volume:read
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/RetrieveDataVolumeRequest"
-        required: true
+            examples:
+              Successful Retrieve Response:
+                $ref: "#/components/examples/SuccessfulRetrieveResponse
+              Successful Retrieve Response With Unknown Status Time:
+                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime
       responses:
         "200":
           description: Contains information about the remaining device data volume.
@@ -117,6 +122,8 @@ paths:
               examples:
                 Successful Response:
                   $ref: "#/components/examples/SuccessfulRetrieveResponse"
+                Successful Retrieve Response With Unknown Status Time:
+                  $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime"
                 Successful Response With Device Disambiguation:
                   $ref: "#/components/examples/SuccessfulRetrieveResponseWithDeviceDisambiguation"
         "400":
@@ -145,11 +152,16 @@ paths:
         - openId:
             - device-data-volume:read
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/CheckDataVolumeRequest"
-        required: true
+            examples:
+              Successful Retrieve Response:
+                $ref: "#/components/examples/SuccessfulRetrieveResponse
+              Successful Retrieve Response With Unknown Status Time:
+                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime
       responses:
         "200":
           description: Boolean response indicating if the remaining data volume exceeds the provided threshold
@@ -163,6 +175,8 @@ paths:
               examples:
                 Successful Response:
                   $ref: "#/components/examples/SuccessfulCheckResponse"
+                Successful Check Response With Unknown Status Time:
+                  $ref: "#/components/examples/SuccessfulCheckResponseWithUnknownStatusTime"
                 Successful Response With Device Disambiguation:
                   $ref: "#/components/examples/SuccessfulCheckResponseWithDeviceDisambiguation"
         "400":
@@ -184,6 +198,15 @@ components:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
 
   schemas:
+    LastStatusTime:
+      description: |
+        The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
+        It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      allOf:
+        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+        - type: object
+          nullable: true
+
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.
       type: string
@@ -230,14 +253,17 @@ components:
     CheckDataVolumeResponse:
       description: Represents the response, if the data volume exceeds a given threshold.
       type: object
+      required:
+        - lastStatusTime
+        - thresholdExceeded
       properties:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+        lastStatusTime:
+          $ref: "#/components/schemas/LastStatusTime"
         thresholdExceeded:
           type: boolean
           description: Indicates whether the remaining data volume exceeds the given threshold
-      required:
-        - thresholdExceeded
 
     RetrieveDataVolumeRequest:
       description: |
@@ -251,32 +277,49 @@ components:
     RetrieveDataVolumeResponse:
       description: Represents the remaining data volume of the requested device.
       type: object
+      required:
+        - lastStatusTime
+        - dataVolumeCategory
       properties:
         device:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
+        lastStatusTime:
+          $ref: "#/components/schemas/LastStatusTime"
         dataVolumeCategory:
           $ref: "#/components/schemas/DataVolumeCategory"
-      required:
-        - dataVolumeCategory
 
   examples:
     SuccessfulRetrieveResponse:
-      description: Successfully retrieve the device data volume category
+      description: Successfully retrieve the device data volume category with known status time
       value:
+        lastStatusTime: "2024-02-20T10:41:38.657Z"
+        dataVolumeCategory: "<200MiB"
+    SuccessfulRetrieveResponseWithUnknownStatusTime:
+      description: Successfully retrieve the device data volume category, but status time of that information is unknown
+      value:
+        lastStatusTime: null
         dataVolumeCategory: "<200MiB"
     SuccessfulRetrieveResponseWithDeviceDisambiguation:
       description: Successfully retrieve the device data volume category but device disambiguation is required
       value:
         device:
           phoneNumber: "+123456789"
+        lastStatusTime: "2024-02-20T10:41:38.657Z"
         dataVolumeCategory: "<200MiB"
     SuccessfulCheckResponse:
-      description: Successfully check the device data volume category
+      description: Successfully check the device data volume category with known status time
       value:
+        lastStatusTime: "2024-02-20T10:41:38.657Z"
+        thresholdExceeded: false
+    SuccessfulCheckResponseWithUnknownStatusTime:
+      description: Successfully check the device data volume category, but status time of that information is unknown
+      value:
+        lastStatusTime: null
         thresholdExceeded: false
     SuccessfulCheckResponseWithDeviceDisambiguation:
       description: Successfully check the device data volume category but device disambiguation is required
       value:
         device:
           phoneNumber: "+123456789"
+        lastStatusTime: "2024-02-20T10:41:38.657Z"
         thresholdExceeded: true

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,10 +202,12 @@ components:
       description: |
         The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        - type: string
-          nullable: true
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
+      nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -200,13 +200,17 @@ components:
   schemas:
     LastStatusTime:
       description: |
-        The last time that the device roaming status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
+        The last time that the device date volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      type: string
-      format: date-time
-      maxLength: 64
-      example: "2018-04-05T17:31:00Z"
-      nullable: true
+      allOf:
+        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+        - nullable: true
+
+#      type: string
+#      format: date-time
+#      maxLength: 64
+#      example: "2018-04-05T17:31:00Z"
+#      nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -105,10 +105,10 @@ paths:
             schema:
               $ref: "#/components/schemas/RetrieveDataVolumeRequest"
             examples:
-              Successful Retrieve Response:
-                $ref: "#/components/examples/SuccessfulRetrieveResponse"
-              Successful Retrieve Response With Unknown Status Time:
-                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime"
+              Retrieve Request:
+                $ref: "#/components/examples/RetrieveRequest"
+              Retrieve Request With 2-legged Access Token:
+                $ref: "#/components/examples/RetrieveRequestWith2-leggedAccessToken"
       responses:
         "200":
           description: Contains information about the remaining device data volume.
@@ -158,10 +158,10 @@ paths:
             schema:
               $ref: "#/components/schemas/CheckDataVolumeRequest"
             examples:
-              Successful Retrieve Response:
-                $ref: "#/components/examples/SuccessfulRetrieveResponse"
-              Successful Retrieve Response With Unknown Status Time:
-                $ref: "#/components/examples/SuccessfulRetrieveResponseWithUnknownStatusTime"
+              Check Request:
+                $ref: "#/components/examples/CheckRequest"
+              Retrieve Request With 2-legged Access Token:
+                $ref: "#/components/examples/CheckRequestWith2-leggedAccessToken"
       responses:
         "200":
           description: Boolean response indicating if the remaining data volume exceeds the provided threshold
@@ -289,6 +289,14 @@ components:
           $ref: "#/components/schemas/DataVolumeCategory"
 
   examples:
+    RetrieveRequest:
+      description: Request device data volume category with 3-legged access token
+      value: {}
+    RetrieveRequestWith2-leggedAccessToken:
+      description: Request device data volume category with 2-legged access token
+      value:
+        device:
+          phoneNumber: "+123456789"
     SuccessfulRetrieveResponse:
       description: Successfully retrieve the device data volume category with known status time
       value:
@@ -306,6 +314,14 @@ components:
           phoneNumber: "+123456789"
         lastStatusTime: "2024-02-20T10:41:38.657Z"
         dataVolumeCategory: "<200MiB"
+    CheckRequest:
+      description: Request device data volume category check with 3-legged access token
+      value: {}
+    CheckRequestWith2-leggedAccessToken:
+      description: Request device data volume category check with 2-legged access token
+      value:
+        device:
+          phoneNumber: "+123456789"
     SuccessfulCheckResponse:
       description: Successfully check the device data volume category with known status time
       value:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,10 +202,9 @@ components:
       description: |
         The last time that the device date volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      nullable: true
       allOf:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        - type: string
-          nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,8 +202,9 @@ components:
       description: |
         The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      type: string
       allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/Device"
+        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
       nullable: true
 
     VolumeUnitEnum:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -316,12 +316,14 @@ components:
         dataVolumeCategory: "<200MiB"
     CheckRequest:
       description: Request device data volume category check with 3-legged access token
-      value: {}
+      value:
+        volumeToCheck: "<200MiB"
     CheckRequestWith2-leggedAccessToken:
       description: Request device data volume category check with 2-legged access token
       value:
         device:
           phoneNumber: "+123456789"
+        volumeToCheck: "<200MiB"
     SuccessfulCheckResponse:
       description: Successfully check the device data volume category with known status time
       value:

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -206,11 +206,11 @@ components:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
         - nullable: true
 
-#      type: string
-#      format: date-time
-#      maxLength: 64
-#      example: "2018-04-05T17:31:00Z"
-#      nullable: true
+      #      type: string
+      #      format: date-time
+      #      maxLength: 64
+      #      example: "2018-04-05T17:31:00Z"
+      #      nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -203,9 +203,10 @@ components:
         The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       type: string
-      allOf:
-        - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
+      format: date-time
+      maxLength: 64
       nullable: true
+      example: "2018-04-05T17:31:00Z"
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -204,7 +204,8 @@ components:
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       allOf:
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
-        - nullable: true
+        - type: string
+          nullable: true
 
     VolumeUnitEnum:
       description: Enumeration of volume units, where "MiB" is 2^20 bytes and "GiB" is 2^30 bytes.

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -202,8 +202,8 @@ components:
       description: |
         The last time that the device data volume status was confirmed to be correct by the API provider. It might not be possible to provide the current status because, for example, the device may not be connected to any mobile network.
         It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-      type: string
       allOf:
+        - type: string
         - $ref: "../common/CAMARA_common.yaml#/components/schemas/DateTime"
       nullable: true
 

--- a/code/API_definitions/device-data-volume.yaml
+++ b/code/API_definitions/device-data-volume.yaml
@@ -205,7 +205,6 @@ components:
       type: string
       format: date-time
       maxLength: 64
-      description: Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       example: "2018-04-05T17:31:00Z"
       nullable: true
 


### PR DESCRIPTION
#### What type of PR is this?
* enhancement/feature

#### What this PR does / why we need it:
This PR adds lastStatusTime field to successful responses with updated examples

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #83 

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Add lastStatusTime field to successful responses with examples
```

#### Additional documentation 
None