### PR TITLE
[Admin] Add sinkCredential property back into Subscription schema

### DIFF
--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -428,6 +428,8 @@ components:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Protocol"
         sink:
           $ref: "#/components/schemas/Sink"
+        sinkCredential:
+          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription for device data volume.


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
The Subscription schema should have a `sinkCredential` property, as the `writeOnly` directive prevents sensitive information being included in the response. The validation error has now been removed.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #91 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - [Admin] Add sinkCredential property back into Subscription schema
```

#### Additional documentation 
None