### PR TITLE
[Added] Update happy path tests to include validation of lastStatusTime property

### DIFF
--- a/code/Test_definitions/device-data-volume-checkDataVolume.feature
+++ b/code/Test_definitions/device-data-volume-checkDataVolume.feature
@@ -33,6 +33,7 @@ Feature: CAMARA Device Data Volume API, vwip - Operation checkDataVolume
     And the response body complies with the OAS schema at "#/components/schemas/CheckDataVolumeResponse"
     And the remaining data volume is above the requested threshold
     And the response body property "$.thresholdExceeded" is present and has value "true"
+    And the response body property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
   @device_data_volume_checkDataVolume_200.02_check_threshold_not_exceeded
   Scenario: Check if the remaining data volume for a device is not above a given threshold
@@ -45,6 +46,7 @@ Feature: CAMARA Device Data Volume API, vwip - Operation checkDataVolume
     And the response body complies with the OAS schema at "#/components/schemas/CheckDataVolumeResponse"
     And the remaining data volume is below the requested threshold
     And the response body property "$.thresholdExceeded" is present and has value "false"
+    And the response body property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
 #################
 # Error scenarios for management of input parameter device

--- a/code/Test_definitions/device-data-volume-retrieveDataVolume.feature
+++ b/code/Test_definitions/device-data-volume-retrieveDataVolume.feature
@@ -33,6 +33,7 @@ Feature: CAMARA Device Data Volume API, vwip - Operation retrieveDataVolume
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response body complies with the OAS schema at "#/components/schemas/RetrieveDataVolumeResponse"
     And the response body property "$.dataVolumeCategory" is present and has value "<200MiB", "<1GiB",  "<5GiB", or ">=5GiB"
+    And the response body property "$.lastStatusTime" is present and either has a valid date-time format for a time in the past, or is null
 
 #################
 # Error scenarios for management of input parameter device


### PR DESCRIPTION
#### What type of PR is this?
* tests

#### What this PR does / why we need it:
`lastStatusTime` is now required in the happy path response body, but the tests have not yet been updated to reflect this. This PR updates the happy path tests to validate this property is present and has a valid value.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #96

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Update happy path tests to include validation of lastStatusTime property
```

#### Additional documentation 
None