### PR TITLE
[Added] Add additional device data volume status subscription list scenarios and move to separate feature file

### DIFF
--- a/code/Test_definitions/device-data-volume-subscriptions-retrieveDeviceDataVolumeSubscriptionList
+++ b/code/Test_definitions/device-data-volume-subscriptions-retrieveDeviceDataVolumeSubscriptionList
@@ -1,0 +1,203 @@
+# device-data-volume-subscriptions-retrieveDeviceDataVolumeSubscriptionList
+Feature: Device Data Volume Subscriptions API, vwip - Operation retrieveDeviceDataVolumeSubscriptionList
+
+  # Input to be provided by the implementation to the tester
+  #
+  # If the subscription leverages the 'device' object the following indication must be present:
+  #    Implementation indications:
+  #      * List of device identifier types which are not supported, such as: phoneNumber, networkAccessIdentifier, ipv4Address, ipv6Address
+  #
+  # Testing assets:
+  #       A sink-url identified as "callbackUrl", which receives notifications
+  #       A device object which device data volume is known by the network when connected.
+  #       The known device data volume status of the testing device
+  #
+  # References to OAS spec schemas refer to schemas specified in device-data-volume-subscriptions.yaml
+
+  Background: Common Device Data Volume Subscriptions setup
+    Given the resource "{apiroot}/device-data-volume-subscriptions/vwip/subscriptions" as base-url
+    And the header "Authorization" is set to a valid access token
+    And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"
+
+##########################
+# Happy path scenarios
+##########################
+
+  @device_data_volume_subscriptions_01_operation_to_retrieve_list_of_subscriptions_2legs
+  Scenario: Get a list of subscriptions for a 2-legged access token
+    Given an API consumer that has created at least one device data volume status subscription
+    And the header "Authorization" is set to a valid access token which does not identify any device
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And each item in the response body array "$.subscriptions" complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" includes all subscriptions created by the API consumer
+    And the response body array "$.subscriptions" does not include any subscriptions created by a different API consumer
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+
+  @device_data_volume_subscriptions_02_operation_to_retrieve_list_of_subscriptions_3legs
+  Scenario: Get a list of subscriptions for a 3-legged access token
+    Given an API consumer that has created at least one device data volume status subscription for a given device
+    And the header "Authorization" is set to a valid access token which identifies that device
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And each item in the response body array "$.subscriptions" complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body array "$.subscriptions" includes all subscriptions created by the API consumer for the identified device
+    And the response body array "$.subscriptions" does not include any subscriptions created by the API consumer for a different device
+    And the response body array "$.subscriptions" does not include any subscriptions created by a different API consumer
+    And the response body property "$.subscriptions[*].config.subscriptionDetail.device" is not present for any of the subscription records
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+
+  @device_data_volume_subscriptions_03_operation_to_retrieve_list_of_subscriptions_when_no_records
+  Scenario: Get a list of device data volume status subscriptions when no subscriptions are available
+    Given an API consumer that has created no device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" is an empty array
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+
+  @device_data_volume_subscriptions_04_pagination_default_values
+  Scenario: Subscription list pagination with default values for page and perPage
+    Given an API consumer who has created more than 20 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent without setting query parameters "page" and "perPage"
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the next page with rel="next"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 1
+    And the response body property "$.pagination.perPage" is 20
+
+  @device_data_volume_subscriptions_05_pagination_custom_values
+  Scenario: Subscription list pagination with custom values for page and perPage
+    Given an API consumer who has created more than 40 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent with query parameters "page" set to 1 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the next page with rel="next"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 1
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is greater than 2
+    And the response body property "$.pagination.totalCount", if present, is greater than 40
+
+  @device_data_volume_subscriptions_06_pagination_middle_page
+  Scenario: Subscription list pagination fetching a middle page of the list
+    Given an API consumer who has created more than 40 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent with query parameters "page" set to 2 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the previous page with rel="prev" and a link to the next page with rel="next"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" has 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 2
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is greater than 2
+    And the response body property "$.pagination.totalCount", if present, is greater than 40
+
+  @device_data_volume_subscriptions_07_pagination_last_page
+  Scenario: Subscription list pagination fetching the last page of the list
+    Given an API consumer who has created more than 40 and less than 60 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent with query parameters "page" set to 3 and "perPage" set to 20
+    Then the response code is 200
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has the same value as the request header "x-correlator"
+    And the response header "Link" contains a link to the previous page with rel="prev"
+    And the response header "X-Total-Pages" is equal to the value of the response body property "$.pagination.totalPages"
+    And the response header "X-Total-Count" is equal to the value of the response body property "$.pagination.totalCount"
+    And the response body complies with the OAS schema at "#/components/schemas/SubscriptionList"
+    And the response body array "$.subscriptions" has between 1 and 20 items and each item complies with the OAS schema at "#/components/schemas/Subscription"
+    And the response body property "$.pagination" complies with the OAS schema at "#/components/schemas/Pagination"
+    And the response body property "$.pagination.page" is 3
+    And the response body property "$.pagination.perPage" is 20
+    And the response body property "$.pagination.totalPages", if present, is 3
+    And the response body property "$.pagination.totalCount", if present, is greater than 40 and less than 60
+
+##################
+# Error code 400
+##################
+
+  @device_data_volume_subscriptions_retrieve_list_400.01_pagination_invalid_page_parameter
+  Scenario: Subscription list pagination with invalid value for page parameter
+    Given an API consumer who has created more than 20 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent with query parameter "page" set to any value less than 1 and "perPage" set to 20
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+  @device_data_volume_subscriptions_retrieve_list_400.02_pagination_invalid_perPage_parameter
+  Scenario: Subscription list pagination with invalid value for perPage parameter
+    Given an API consumer who has created more than 20 device data volume status subscriptions
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent with query parameter "page" set to 1 and "perPage" set to any value outside the range [1-100]
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" contains a user friendly text
+
+##################
+# Error code 401
+##################
+
+  @device_data_volume_subscriptions_retrieve_list_401.01_no_authorization_header
+  Scenario: No Authorization header
+    Given the request header "Authorization" is removed
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @device_data_volume_subscriptions_retrieve_list_401.02_expired_access_token
+  Scenario: Expired access token
+    Given the header "Authorization" is set to a previously valid but now expired access token
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+  @device_data_volume_subscriptions_retrieve_list_401.03_malformed_access_token
+  Scenario: Malformed access token
+    Given the header "Authorization" is set to a malformed token
+    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
+    Then the response status code is 401
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 401
+    And the response property "$.code" is "UNAUTHENTICATED"
+    And the response property "$.message" contains a user friendly text
+
+##################
+# Error code 403
+##################
+
+##################
+# Error code 404
+##################
+
+##################
+# Error code 422
+##################

--- a/code/Test_definitions/device-data-volume-subscriptions.feature
+++ b/code/Test_definitions/device-data-volume-subscriptions.feature
@@ -1,4 +1,5 @@
-Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
+# device-data-volume-subscriptions
+Feature: Device Data Volume Subscriptions API, vwip - Operations createDeviceDataVolumeSubscription, retrieveDeviceDataVolumeSubscription, deleteDeviceDataVolumeSubscription
 
   # Input to be provided by the implementation to the tester
   #
@@ -12,6 +13,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
   #       The known device data volume status of the testing device
   #
   # References to OAS spec schemas refer to schemas specified in device-data-volume-subscriptions.yaml
+
   Background: Common Device Data Volume Subscription setup
     Given an environment at "apiRoot"
     And the resource "/device-data-volume-subscriptions/vwip/subscriptions"
@@ -117,40 +119,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the response property "$.id" is equal to "id"
     And the response property "$.config.subscriptionDetail.device" is not present
 
-  @device_data_volume_subscriptions_04_retrieve_list_2legs
-  Scenario: Check existing subscription(s) is/are retrieved in list with 2-legged-token
-    Given at least one subscription is existing for the API consumer making this request
-    And the header "Authorization" is set to a valid access token which does not identify any device
-    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer
-
-  @device_data_volume_subscriptions_05_retrieve_list_3legs
-  Scenario: Check existing subscription(s) is/are retrieved in list with 3-legged-token
-    Given the API consumer has at least one active subscription for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device associated with one or more subscriptions
-    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body complies with an array of OAS schema defined at "#/components/schemas/Subscription"
-    And the response body lists all subscriptions belonging to the API consumer for the identified device
-    And the response property "$.config.subscriptionDetail.device" is not present in any of the subscription records
-
-  @device_data_volume_subscriptions_06_retrieve_empty_list_3legs
-  Scenario: Check no existing subscription is retrieved in list
-    Given the API consumer has no active subscriptions for the device
-    And the header "Authorization" is set to a valid access token which identifies a valid device
-    When the request "retrieveDeviceDataVolumeSubscriptionList" is sent
-    Then the response status code is 200
-    And the response header "Content-Type" is "application/json"
-    And the response header "x-correlator" has same value as the request header "x-correlator"
-    And the response body is an empty array
-
-  @device_data_volume_subscriptions_07_delete_subscription_based_on_an_existing_subscription-id
+  @device_data_volume_subscriptions_04_delete_subscription_based_on_an_existing_subscription-id
   Scenario: Delete the subscription with subscriptionId equal to "id"
     Given the API consumer has an active subscription with "subscriptionId" equal to "id"
     When the request "deleteDeviceDataVolumeSubscription" is sent
@@ -160,7 +129,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And if the response property "$.status" is 204 then response body is not present
     And if the response property "$.status" is 202 then response body complies with the OAS schema at "#/components/schemas/SubscriptionAsync" and the response property "$.id" is equal to "id"
 
-  @device_data_volume_subscriptions_08_receive_notification_when_device_consumed_50_percent_of_the_data_plan
+  @device_data_volume_subscriptions_05_receive_notification_when_device_consumed_50_percent_of_the_data_plan
   Scenario: Receive notification for data-50-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
     And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent"
@@ -172,7 +141,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
-  @device_data_volume_subscriptions_09_receive_notification_when_device_consumed_75_percent_of_the_data_plan
+  @device_data_volume_subscriptions_06_receive_notification_when_device_consumed_75_percent_of_the_data_plan
   Scenario: Receive notification for data-75-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
     And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent"
@@ -184,7 +153,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
-  @device_data_volume_subscriptions_10_receive_notification_when_device_consumed_90_percent_of_the_data_plan
+  @device_data_volume_subscriptions_07_receive_notification_when_device_consumed_90_percent_of_the_data_plan
   Scenario: Receive notification for data-90-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
     And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent"
@@ -196,7 +165,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
-  @device_data_volume_subscriptions_11_receive_notification_when_the_data_plan_is_exceeded
+  @device_data_volume_subscriptions_08_receive_notification_when_the_data_plan_is_exceeded
   Scenario: Receive notification for data-exceeded event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
     And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
@@ -208,7 +177,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
-  @device_data_volume_subscriptions_12_subscription_expiry
+  @device_data_volume_subscriptions_09_subscription_expiry
   Scenario: Receive notification for subscription-ended event on expiry
     Given a valid subscription for a device exists with "subscriptionId" equal to "id"
     And the subscription property "$.subscriptionExpireTime" is set to a value in the near future
@@ -220,7 +189,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.data.subscriptionId" is equal to "id"
     And the notification property "$.data.terminationReason" is equal to "SUBSCRIPTION_EXPIRED"
 
-  @device_data_volume_subscriptions_13_subscription_end_when_max_events
+  @device_data_volume_subscriptions_10_subscription_end_when_max_events
   Scenario: Receive notification for subscription-ended event on max events reached
     Given a valid subscription for a device exists with "subscriptionId" equal to "id"
     And the subscription property "$.subscriptionMaxEvents" is set to 1
@@ -232,7 +201,7 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the notification property "$.data.subscriptionId" is equal to "id"
     And the notification request property "$.data.terminationReason" is equal to "MAX_EVENTS_REACHED"
 
-  @device_data_volume_subscriptions_14_subscription_delete_event_validation
+  @device_data_volume_subscriptions_11_subscription_delete_event_validation
   Scenario: Receive notification for subscription-ended event on deletion
     Given a valid subscription for a device exists with "subscriptionId" equal to "id"
     And the subscription property "$.sink" is a valid callback URL


### PR DESCRIPTION
#### What type of PR is this?
* tests

#### What this PR does / why we need it:
Updates scenarios for retrieving device data volume status subscriptions to improve clarity and detail. Added pagination scenarios and refined existing scenarios for better compliance with OAS schema.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #105 

#### Special notes for reviewers:
Tests copied from Commonalities template [here](https://github.com/camaraproject/Commonalities/blob/main/artifacts/testing/event-subscription-template.feature)

#### Changelog input
```
 release-note
 - Add additional device data volume status subscription list scenarios and move to separate feature file
```

#### Additional documentation 
None