### PR TITLE
[Changed, Breaking] Rename data allowance consumption events for clarity

### DIFF
--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -397,10 +397,10 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining: "#/components/schemas/EventDataUsage50Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining: "#/components/schemas/EventDataUsage25Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining: "#/components/schemas/EventDataUsage10Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining: "#/components/schemas/EventDataUsage00Percent"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining: "#/components/schemas/EventDataUsage50PercentRemaining"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining: "#/components/schemas/EventDataUsage25PercentRemaining"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining: "#/components/schemas/EventDataUsage10PercentRemaining"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining: "#/components/schemas/EventDataUsage00PercentRemaining"
 
     NotificationEvent:
       description: |

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -25,15 +25,15 @@ info:
     When subscribing, it is mandatory to provide the event `types` related to data volume thresholds you wish to track.
 
     The following event `types` are managed for this API:
-      - `org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent`: Event triggered when 50% of the data plan is consumed.
-      - `org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent`: Event triggered when 75% of the data plan is consumed.
-      - `org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent`: Event triggered when 90% of the data plan is consumed.
-      - `org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded`: Event triggered when the data plan is exceeded.
+      - `org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining`: Event triggered when only 50% of the data plan is remaining
+      - `org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining`: Event triggered when only 25% of the data plan is remaining
+      - `org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining`: Event triggered when only 10% of the data plan is remaining
+      - `org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining`: Event triggered when the data plan is fully consumed
 
     Note: Additionally, the following events could be send, which do not require a dedicated subscription:
-      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-started` is sent when the subscription starts.
-      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-updated` is sent when the subscription is updated.
-      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-ended` is sent when the subscription ends.
+      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-started` is sent when the subscription starts
+      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-updated` is sent when the subscription is updated
+      - `org.camaraproject.device-data-volume-subscriptions.v0.subscription-ended` is sent when the subscription ends
 
     It is used in following cases:
       - the subscription expire time (optionally set by the requester) has been reached
@@ -123,10 +123,10 @@ paths:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       security:
         - openId:
-            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent:create
-            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent:create
-            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent:create
-            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded:create
+            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining:create
+            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining:create
+            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining:create
+            - device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining:create
       requestBody:
         content:
           application/json:
@@ -151,14 +151,14 @@ paths:
                     schema:
                       $ref: "#/components/schemas/NotificationEvent"
                     examples:
-                      data-50-percent:
-                        $ref: "#/components/examples/DATA_50_PERCENT"
-                      data-75-percent:
-                        $ref: "#/components/examples/DATA_75_PERCENT"
-                      data-90-percent:
-                        $ref: "#/components/examples/DATA_90_PERCENT"
-                      data-exceeded:
-                        $ref: "#/components/examples/DATA_EXCEEDED"
+                      data-50-percent-remaining:
+                        $ref: "#/components/examples/DATA_50_PERCENT_REMAINING"
+                      data-25-percent-remaining:
+                        $ref: "#/components/examples/DATA_75_PERCENT_REMAINING"
+                      data-10-percent-remaining:
+                        $ref: "#/components/examples/DATA_90_PERCENT_REMAINING"
+                      data-0-percent-remaining:
+                        $ref: "#/components/examples/DATA_00_PERCENT_REMAINING"
                       subscription-started:
                         $ref: "#/components/examples/SUBSCRIPTION_STARTED"
                       subscription-updated:
@@ -376,10 +376,10 @@ components:
       description: |
         Event types that can be triggered for device data volume monitoring.
       enum:
-        - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
-        - org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent
-        - org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent
-        - org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining
+        - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
 
     ApiNotificationEvent:
       description: |
@@ -397,10 +397,10 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent: "#/components/schemas/EventDataUsage50Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent: "#/components/schemas/EventDataUsage75Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent: "#/components/schemas/EventDataUsage90Percent"
-          org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded: "#/components/schemas/EventDataUsageExceeded"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining: "#/components/schemas/EventDataUsage50Percent"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining: "#/components/schemas/EventDataUsage25Percent"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining: "#/components/schemas/EventDataUsage10Percent"
+          org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining: "#/components/schemas/EventDataUsage00Percent"
 
     NotificationEvent:
       description: |
@@ -580,8 +580,8 @@ components:
         subscriptionId:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
 
-    EventDataUsage50Percent:
-      description: Event structure for data usage 50% threshold alerts
+    EventDataUsage50PercentRemaining:
+      description: Event structure for remaining data allowance below 50% threshold alerts
       allOf:
         - $ref: "#/components/schemas/ApiNotificationEvent"
         - type: object
@@ -589,8 +589,8 @@ components:
             data:
               $ref: "#/components/schemas/BasicDeviceEventData"
 
-    EventDataUsage75Percent:
-      description: Event structure for data usage 75% threshold alerts
+    EventDataUsage25PercentRemaining:
+      description: Event structure for remaining data allowance below 25% threshold alerts
       allOf:
         - $ref: "#/components/schemas/ApiNotificationEvent"
         - type: object
@@ -598,8 +598,8 @@ components:
             data:
               $ref: "#/components/schemas/BasicDeviceEventData"
 
-    EventDataUsage90Percent:
-      description: Event structure for data usage 90% threshold alerts
+    EventDataUsage10PercentRemaining:
+      description: Event structure for remaining data allowance below 10% threshold alerts
       allOf:
         - $ref: "#/components/schemas/ApiNotificationEvent"
         - type: object
@@ -607,8 +607,8 @@ components:
             data:
               $ref: "#/components/schemas/BasicDeviceEventData"
 
-    EventDataUsageExceeded:
-      description: Event structure for data usage exceeding the allocated volume
+    EventDataUsage00PercentRemaining:
+      description: Event structure for remaining data allowance below 0% threshold alerts
       allOf:
         - $ref: "#/components/schemas/ApiNotificationEvent"
         - type: object
@@ -685,12 +685,12 @@ components:
               $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
 
   examples:
-    DATA_50_PERCENT:
-      description: Example of data-50-percent notification
+    DATA_50_PERCENT_REMAINING:
+      description: Example of data-50-percent-remaining notification
       value:
         id: "124007"
         source: https://dataUsageServer.supertelco.com
-        type: org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
+        type: org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining
         specversion: "1.0"
         datacontenttype: application/json
         data:
@@ -699,12 +699,12 @@ components:
           subscriptionId: "dv10-h556-rt89-1406"
         time: "2024-05-12T12:45:23.682Z"
 
-    DATA_75_PERCENT:
-      description: Example of data-75-percent notification
+    DATA_25_PERCENT_REMAINING:
+      description: Example of data-25-percent-remaining notification
       value:
         id: "124008"
         source: https://dataUsageServer.supertelco.com
-        type: org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent
+        type: org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent
         specversion: "1.0"
         datacontenttype: application/json
         data:
@@ -713,12 +713,12 @@ components:
           subscriptionId: "dv10-h556-rt89-1407"
         time: "2024-05-12T14:30:23.682Z"
 
-    DATA_90_PERCENT:
-      description: Example of data-90-percent notification
+    DATA_10_PERCENT_REMAINING:
+      description: Example of data-10-percent-remaining notification
       value:
         id: "124009"
         source: https://dataUsageServer.supertelco.com
-        type: org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent
+        type: org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining
         specversion: "1.0"
         datacontenttype: application/json
         data:
@@ -727,12 +727,12 @@ components:
           subscriptionId: "dv10-h556-rt89-1408"
         time: "2024-05-12T16:15:23.682Z"
 
-    DATA_EXCEEDED:
-      description: Example of data-exceeded notification
+    DATA_00_PERCENT_REMAINING:
+      description: Example of data-00-percent-remaining notification
       value:
         id: "124010"
         source: https://dataUsageServer.supertelco.com
-        type: org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded
+        type: org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
         specversion: "1.0"
         datacontenttype: application/json
         data:
@@ -794,7 +794,7 @@ components:
           method: POST
         sink: https://endpoint.example.com/sink
         types:
-          - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
+          - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining
         config:
           subscriptionDetail: {}
           subscriptionExpireTime: '2023-01-17T13:18:23.682Z'
@@ -813,7 +813,7 @@ components:
           method: POST
         sink: https://endpoint.example.com/sink
         types:
-          - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent
+          - org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining
         config:
           subscriptionDetail:
             device:
@@ -833,7 +833,7 @@ components:
         sink: https://endpoint.example.com/sink
         protocol: HTTP
         types:
-          - "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+          - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
         config:
           subscriptionDetail: {}
           subscriptionExpireTime: "2024-08-01T14:18:23.682Z"
@@ -850,7 +850,7 @@ components:
         sink: https://endpoint.example.com/sink
         protocol: HTTP
         types:
-          - "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+          - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
         config:
           subscriptionDetail:
             device:
@@ -870,7 +870,7 @@ components:
             sink: https://endpoint.example.com/sink
             protocol: HTTP
             types:
-              - "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+          - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
             config:
               subscriptionDetail: {}
               subscriptionExpireTime: "2024-07-17T13:18:23.682Z"

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -704,7 +704,7 @@ components:
       value:
         id: "124008"
         source: https://dataUsageServer.supertelco.com
-        type: org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent
+        type: org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining
         specversion: "1.0"
         datacontenttype: application/json
         data:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -154,9 +154,9 @@ paths:
                       data-50-percent-remaining:
                         $ref: "#/components/examples/DATA_50_PERCENT_REMAINING"
                       data-25-percent-remaining:
-                        $ref: "#/components/examples/DATA_75_PERCENT_REMAINING"
+                        $ref: "#/components/examples/DATA_25_PERCENT_REMAINING"
                       data-10-percent-remaining:
-                        $ref: "#/components/examples/DATA_90_PERCENT_REMAINING"
+                        $ref: "#/components/examples/DATA_10_PERCENT_REMAINING"
                       data-0-percent-remaining:
                         $ref: "#/components/examples/DATA_00_PERCENT_REMAINING"
                       subscription-started:

--- a/code/API_definitions/device-data-volume-subscriptions.yaml
+++ b/code/API_definitions/device-data-volume-subscriptions.yaml
@@ -870,7 +870,7 @@ components:
             sink: https://endpoint.example.com/sink
             protocol: HTTP
             types:
-          - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
+              - org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining
             config:
               subscriptionDetail: {}
               subscriptionExpireTime: "2024-07-17T13:18:23.682Z"

--- a/code/Test_definitions/device-data-volume-subscriptions.feature
+++ b/code/Test_definitions/device-data-volume-subscriptions.feature
@@ -39,11 +39,11 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the response property "$.status", if present, has the value "ACTIVATION_REQUESTED", "ACTIVE" or "INACTIVE"
 
     Examples:
-      | subscription-creation-types                                           |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded   |
+      | subscription-creation-types                                                     |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining |
 
   @device_data_volume_subscriptions_01.1_sync_creation_3legs
   Scenario Outline: Synchronous subscription creation with 3-legged-token
@@ -64,11 +64,11 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the response property "$.config.subscriptionDetail.device" is not present
 
     Examples:
-      | subscription-creation-types                                           |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded   |
+      | subscription-creation-types                                                     |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining |
 
   @device_data_volume_subscriptions_02_async_creation
   Scenario Outline: Asynchronous subscription creation with 2- or 3-legged access token
@@ -85,11 +85,11 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
     And the response property "$.id" is present
 
     Examples:
-      | subscription-creation-types                                           |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent |
-      | org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded   |
+      | subscription-creation-types                                                     |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining |
+      | org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining |
 
   @device_data_volume_subscriptions_03.1_retrieve_by_id_2legs
   Scenario: Check existing subscription is retrieved by id with a 2-legged access token
@@ -163,49 +163,49 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
   @device_data_volume_subscriptions_08_receive_notification_when_device_consumed_50_percent_of_the_data_plan
   Scenario: Receive notification for data-50-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
-    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining"
     And the subscription property "$.sink" is a valid callback URL
     When the device's data volume consumed 50% of the data plan
     Then event notification "data-50-percent" is sent to the specified callback URL
     And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventDataUsage50Percent"
-    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent"
+    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
   @device_data_volume_subscriptions_09_receive_notification_when_device_consumed_75_percent_of_the_data_plan
   Scenario: Receive notification for data-75-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
-    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining"
     And the subscription property "$.sink" is a valid callback URL
     When the device's data volume consumed 75% of the data plan
     Then event notification "data-75-percent" is sent to the specified callback URL
     And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventDataUsage75Percent"
-    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-75-percent"
+    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
   @device_data_volume_subscriptions_10_receive_notification_when_device_consumed_90_percent_of_the_data_plan
   Scenario: Receive notification for data-90-percent event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
-    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining"
     And the subscription property "$.sink" is a valid callback URL
     When the device's data volume consumed 90% of the data plan
     Then event notification "data-90-percent" is sent to the specified callback URL
     And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventDataUsage90Percent"
-    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-90-percent"
+    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
   @device_data_volume_subscriptions_11_receive_notification_when_the_data_plan_is_exceeded
   Scenario: Receive notification for data-exceeded event
     Given a valid subscription for that device exists with "subscriptionId" equal to "id"
-    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+    And the subscription property "$.types" contains the element "org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining"
     And the subscription property "$.sink" is a valid callback URL
     When the device's data plan is exceeded
     Then event notification "data-exceeded" is sent to the specified callback URL
     And the sink credentials specified when the subscription was created are included
     And notification body complies with the OAS schema at "#/components/schemas/EventDataUsage90Percent"
-    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-exceeded"
+    And the notification property "$.type" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining"
     And the notification property "$.data.subscriptionId" is equal to "id"
 
   @device_data_volume_subscriptions_12_subscription_expiry
@@ -448,9 +448,9 @@ Feature: Device Data Volume Subscriptions API, vwip - Operation on subscriptions
   @device_data_volume_subscriptions_create_403.1_permission_denied
   Scenario: Subscription creation for org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent without having the required scope
    # To test this, a token must not have the required scope
-    Given the header "Authorization" set to an access token not including scope "device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent:create"
+    Given the header "Authorization" set to an access token not including scope "device-data-volume-subscriptions:org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining:create"
     And the request body is compliant with the schema "#/components/schemas/SubscriptionRequest"
-    And the request body property "$.types" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent"
+    And the request body property "$.types" is equal to "org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining"
     When the request "createDeviceDataVolumeSubscription" is sent
     Then the response status code is 403
     And the response property "$.status" is 403


### PR DESCRIPTION
#### What type of PR is this?
* documentation
* tests

#### What this PR does / why we need it:
Renames data allowance consumption events for clarity:
      - `org.camaraproject.device-data-volume-subscriptions.v0.data-50-percent-remaining`: Event triggered when only 50% of the data plan is remaining
      - `org.camaraproject.device-data-volume-subscriptions.v0.data-25-percent-remaining`: Event triggered when only 25% of the data plan is remaining
      - `org.camaraproject.device-data-volume-subscriptions.v0.data-10-percent-remaining`: Event triggered when only 10% of the data plan is remaining
      - `org.camaraproject.device-data-volume-subscriptions.v0.data-00-percent-remaining`: Event triggered when the data plan is fully consumed

This provides a consistent event naming structure for adding additional events

Updates associated tests

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #99

#### Special notes for reviewers:
None

#### Changelog input
```
 release-note
 - Rename data allowance consumption events for clarity
```

#### Additional documentation 
None